### PR TITLE
Fix NPE when parsing blaze test errors without a message

### DIFF
--- a/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlToTestEventsConverter.java
+++ b/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlToTestEventsConverter.java
@@ -383,7 +383,7 @@ public class BlazeXmlToTestEventsConverter extends OutputToGeneralTestEventsConv
       String name, ErrorOrFailureOrSkipped error, long duration) {
     String message =
         error.message != null ? error.message : "Test failed (no error message present)";
-    String content = pruneErrorMessage(error.message, BlazeXmlSchema.getErrorContent(error));
+    String content = pruneErrorMessage(message, BlazeXmlSchema.getErrorContent(error));
     return getTestFailedEvent(name, message, content, parseComparisonData(error), duration);
   }
 

--- a/base/tests/unittests/com/google/idea/blaze/base/run/smrunner/BlazeXmlSchemaTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/run/smrunner/BlazeXmlSchemaTest.java
@@ -174,6 +174,29 @@ public class BlazeXmlSchemaTest {
     assertThat(BlazeXmlSchema.getErrorContent(testCase.errors.get(0))).isNull();
   }
 
+  @Test
+  public void testErrorWithoutMessage() {
+    TestSuite parsed =
+        parseXml(
+            "<?xml version='1.0' encoding='UTF-8'?>",
+            "<testsuites>",
+            "  <testsuite name='com.google.ConfigTest' tests='1' failures='0' errors='1'>",
+            "    <testcase name='testCase1' status='run' duration='55' time='55'>",
+            " <error type='java.lang.NullPointerException'><![CDATA[java.lang.NullPointerException",
+            "  at com.example.MyClass.myMethod(MyClass.java:55)",
+            "]]></error>",
+            "    </testcase>",
+            "  </testsuite>",
+            "</testsuites>");
+
+    ErrorOrFailureOrSkipped error = parsed.testSuites.get(0).testCases.get(0).errors.get(0);
+
+    assertThat(error.type).isEqualTo("java.lang.NullPointerException");
+    assertThat(BlazeXmlSchema.getErrorContent(error))
+        .isEqualTo("java.lang.NullPointerException\n  at com.example.MyClass.myMethod(MyClass.java:55)");
+    assertThat(error.message).isNull();
+  }
+
   private static TestSuite parseXml(String... lines) {
     InputStream stream =
         new ByteArrayInputStream(Joiner.on('\n').join(lines).getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Code like `throw new NullPointerException()` results in a test error that does not have a message. The test result parser is not properly handle this case.

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

